### PR TITLE
colorfilter supports other patch keys

### DIFF
--- a/ScriptEngine/Effects/colorfilter.as
+++ b/ScriptEngine/Effects/colorfilter.as
@@ -1,4 +1,6 @@
 #include "ScriptEngine/Effects/Base/BaseEffect.as"
+#include "ScriptEngine/Utils.as"
+
 
 namespace MaskEngine
 {
@@ -6,7 +8,10 @@ namespace MaskEngine
 class colorfilter : BaseEffectImpl
 {
     private BaseEffect@ _colorPatchEffect;
-    // private 
+
+    private String texturePath = "ColorFilter/lookup.png";
+    private String patchConfigString = "";
+
 
     bool Init(const JSONValue& effect_desc, BaseEffect@ parent) override
     {
@@ -15,16 +20,13 @@ class colorfilter : BaseEffectImpl
             return false;
         }
 
-        float intensity = effect_desc.Get("intensity").isNumber ? effect_desc.Get("intensity").GetFloat() : 1.0; 
-        String lookup = "ColorFilter/lookup.png";
-        if (effect_desc.Get("lookup").isString) {
-            lookup = effect_desc.Get("lookup").GetString();
-        }
-        else {
-            log.Info("colorfilter : lookup not specified, using default \"" + lookup +  "\"" );
-        }
+        ReadConfiguration(effect_desc);
 
-        String patchConfigString = " {  \"name\" : \"patch\" , \"anchor\" : \"fullscreen\", \"visible\" : \"always\", \"texture\" : { \"color\" : [0.0, 0.0, 0.0, " + intensity + "], \"texture\" :  \""  +  lookup + "\", \"shader\" : \"ColorFilter\", \"ps_shader_defs\" : \"INTENSITY_VALUE\" } } ";
+        if (!cache.Exists(texturePath))
+        {
+            log.Error("colorfilter: Texture file does not exist");
+            return false;
+        }
 
         @_colorPatchEffect = AddChildEffect("patch");
         if (_colorPatchEffect !is null)
@@ -45,7 +47,78 @@ class colorfilter : BaseEffectImpl
         return _inited;
     }
 
+    private void ReadConfiguration(const JSONValue& effect_desc)
+    {
+        patchConfigString     += "{\n  \"name\": \"patch\"";
 
+        if (effect_desc.Contains("tag") && effect_desc.Get("tag").isString)
+            patchConfigString += ",\n  \"tag\": \"" + effect_desc.Get("tag").GetString() + "\"";
+
+        if (effect_desc.Contains("anchor") && effect_desc.Get("anchor").isString)
+            patchConfigString += ",\n  \"anchor\": \"" + effect_desc.Get("anchor").GetString() + "\"";
+        else
+            patchConfigString += ",\n  \"anchor\": \"fullscreen\"";
+
+        patchConfigString     += ",\n  \"texture\": {";
+
+        if (effect_desc.Contains("lookup") && effect_desc.Get("lookup").isString)
+        {
+            texturePath = effect_desc.Get("lookup").GetString();
+            patchConfigString += "\n    \"texture\": \"" + texturePath + "\"";
+        }
+        else
+        {
+            log.Info("colorfilter: lookup not specified, using default \"" + texturePath +  "\"");
+            patchConfigString += "\n    \"texture\": \"" + texturePath + "\"";
+        }
+
+        if (effect_desc.Contains("intensity") && effect_desc.Get("intensity").isNumber)
+            patchConfigString += ",\n    \"color\": [0.0, 0.0, 0.0, " + effect_desc.Get("intensity").GetFloat() + "]";
+        else
+            patchConfigString += ",\n    \"color\": [0.0, 0.0, 0.0, " + 1.0 + "]";
+
+        patchConfigString     += ",\n    \"shader\": \"ColorFilter\""
+                              +  ",\n    \"ps_shader_defs\": \"INTENSITY_VALUE\""
+                              +  "\n  }";
+
+        if (effect_desc.Contains("allow_rotation") && effect_desc.Get("allow_rotation").isBool)
+            patchConfigString += ",\n  \"allow_rotation\": " + effect_desc.Get("allow_rotation").GetBool();
+
+        if (effect_desc.Contains("visible") && effect_desc.Get("visible").isString)
+            patchConfigString += ",\n  \"visible\": \"" + effect_desc.Get("visible").GetString() + "\"";
+
+        if (effect_desc.Contains("show_delay") && effect_desc.Get("show_delay").isNumber)
+            patchConfigString += ",\n  \"show_delay\": " + effect_desc.Get("show_delay").GetFloat();
+
+        if (effect_desc.Contains("hide_delay") && effect_desc.Get("hide_delay").isNumber)
+            patchConfigString += ",\n  \"hide_delay\": " + effect_desc.Get("hide_delay").GetFloat();
+
+        if (effect_desc.Contains("fit") && effect_desc.Get("fit").isString)
+            patchConfigString += ",\n  \"fit\": \"" + effect_desc.Get("fit").GetString() + "\"";
+
+        if (effect_desc.Contains("size") && effect_desc.Get("size").isArray)
+        {
+            Vector2 size;
+            ReadVector2(effect_desc.Get("size"), size);
+            patchConfigString += ",\n  \"size\": [" + size.x + ", " + size.y + "]";
+        }
+
+        if (effect_desc.Contains("offset") && effect_desc.Get("offset").isArray)
+        {
+            Vector3 offset;
+            ReadVector3(effect_desc.Get("offset"), offset);
+            patchConfigString += ",\n  \"offset\": [" + offset.x + ", " + offset.y + ", " + offset.z + "]";
+        }
+
+        if (effect_desc.Contains("rotation") && effect_desc.Get("rotation").isArray)
+        {
+            Vector3 rotation;
+            ReadVector3(effect_desc.Get("rotation"), rotation);
+            patchConfigString += ",\n  \"rotation\": [" + rotation.x + ", " + rotation.y + ", " + rotation.z + "]";
+        }
+
+        patchConfigString     += "\n}";
+    }
 
     void _SetVisible(bool visible) override
     {

--- a/ScriptEngine/Utils.as
+++ b/ScriptEngine/Utils.as
@@ -178,6 +178,18 @@ bool    ReadVector3(const JSONValue &jval, Vector3 &dst, bool allow_vector2 = fa
     return false;
 }
 
+bool    ReadVector2(const JSONValue &jval, Vector2 &dst)
+{
+    Array<float> v = { dst.x, dst.y };
+    uint n = ReadFloatVector(jval, v, 2);
+    if (n == 2)
+    {
+        dst = Vector2(v);
+        return true;
+    }
+    return false;
+}
+
 bool  ReadPositionValue(const JSONValue &jval, BillboardPosition &position)
 {
     if (jval.isNumber)


### PR DESCRIPTION
Adds support for `colorfilter` effect to have the same configuration in _mask.json_ as `patch` effect has.  The only exception is the child texture config — in colorfilter it is not animatable (but it could be) and is automatically set to lookup texture.