### PR TITLE
Unified behaivoir for `patch` and `model3d` texture animations

### DIFF
--- a/ScriptEngine/Effects/animation.as
+++ b/ScriptEngine/Effects/animation.as
@@ -220,7 +220,7 @@ class animation : BaseEffectImpl
             float fps = ani_desc.Get("fps").GetFloat();
 
             if (fps < M_EPSILON)
-                fps = 25.f;
+                fps = 30.0f;
 
             double time_step = 1.0 / double(fps);
 

--- a/ScriptEngine/Effects/model3d.as
+++ b/ScriptEngine/Effects/model3d.as
@@ -21,8 +21,8 @@ class model_texture_animation
     String texture_resource;
 
     // From artist's settings in 'mask.json'
-    String trigger_start;
-    String trigger_stop;
+    String trigger_start = "";
+    String trigger_stop = "";
     float fps = 30.0;
 
     // Runtime variables
@@ -65,7 +65,9 @@ class model_texture_animation
             return;
         }
 
-        // Sunscriptions
+        if (texture_desc.Contains("animation") && trigger_start == "")
+            start();
+
         if (trigger_start == "tap" || trigger_stop == "tap")
             SubscribeToEvent("MouseEvent", "HandleTapEvent");
 
@@ -127,9 +129,10 @@ class model_texture_animation
                     trigger_stop = animation_parameters.Get("trigger_stop").GetString();
                 
                 if (animation_parameters.Contains("fps"))
+                {
                     fps = animation_parameters.Get("fps").GetFloat();
-
-                if (animation_parameters.Contains("timeline"))
+                }
+                else if (animation_parameters.Contains("timeline"))
                 {
                     JSONValue timeline = animation_parameters.Get("timeline");
                     if (timeline.isArray && timeline.size > 0)
@@ -170,8 +173,7 @@ class model_texture_animation
                     }
                     hasTimeline = true;
                 }
-
-                if (animation_parameters.Contains("timeline_ex"))
+                else if (animation_parameters.Contains("timeline_ex"))
                 {
                     JSONValue timeline_ex = animation_parameters.Get("timeline_ex");
                     if (timeline_ex.isArray && timeline_ex.size > 0)
@@ -279,8 +281,6 @@ class model_texture_animation
                 stop(trigger_start == "tap");
                 return;
             }
-
-            log.Info("frame: " + frame);
 
             String texture_path = texturePaths[frame];
             Texture@ texture = cache.GetResource(texture_resource, texture_path);


### PR DESCRIPTION
Now animation have the same default parameters:
- 30 fps,
- automatically start if no trigger is set,
- fix: only one mode ("fps", "timeline", "timeline_ex") is chosen in `model3d` texture animation, not the last declared.