### PR TITLE
Feature/split light effect into types

### DIFF
--- a/ScriptEngine/Effects/ambientlight.as
+++ b/ScriptEngine/Effects/ambientlight.as
@@ -1,0 +1,61 @@
+#include "ScriptEngine/Effects/Base/BaseEffect.as"
+
+namespace MaskEngine
+{
+
+class ambientlight : BaseEffectImpl
+{
+    private BaseEffect@ _lightEffect;
+    private JSONValue _lightConfig;
+
+    bool Init(const JSONValue& effect_desc, BaseEffect@ parent) override
+    {
+        if (!BaseEffectImpl::Init(effect_desc, parent))
+        {
+            return false;
+        }
+
+        _lightConfig = JSONValue();
+        ReadConfiguration(effect_desc);
+
+        @_lightEffect = AddChildEffect("light");
+        if (_lightEffect is null)
+        {
+            log.Error("ambientlight: light effect is null");
+            return false;
+        }
+
+        if (!_lightEffect.Init(_lightConfig, parent))
+        {
+            log.Error("ambientlight: cannot init light");
+            return false;
+        }
+
+        AddTags(effect_desc, _lightEffect.GetNode());
+
+        return true;
+    }
+
+    private void ReadConfiguration(const JSONValue& effect_desc)
+    {
+        _lightConfig.Set("type", JSONValue("ambient"));
+
+        if (effect_desc.Contains("color") && effect_desc.Get("color").isArray)
+            _lightConfig.Set("color", effect_desc.Get("color"));
+
+        if (effect_desc.Contains("tag") && effect_desc.Get("tag").isString)
+            _lightConfig.Set("tag", effect_desc.Get("tag"));
+    }
+
+    void _SetVisible(bool visible) override
+    {
+        _lightEffect.SetVisible(visible);
+    }
+
+    String GetName() override
+    {
+        return "ambientlight";
+    }
+}
+
+}

--- a/ScriptEngine/Effects/directlight.as
+++ b/ScriptEngine/Effects/directlight.as
@@ -1,0 +1,73 @@
+#include "ScriptEngine/Effects/Base/BaseEffect.as"
+
+namespace MaskEngine
+{
+
+class directlight : BaseEffectImpl
+{
+    private BaseEffect@ _lightEffect;
+    private JSONValue _lightConfig;
+
+    bool Init(const JSONValue& effect_desc, BaseEffect@ parent) override
+    {
+        if (!BaseEffectImpl::Init(effect_desc, parent))
+        {
+            return false;
+        }
+
+        _lightConfig = JSONValue();
+        ReadConfiguration(effect_desc);
+
+        @_lightEffect = AddChildEffect("light");
+        if (_lightEffect is null)
+        {
+            log.Error("directlight: light effect is null");
+            return false;
+        }
+
+        if (!_lightEffect.Init(_lightConfig, parent))
+        {
+            log.Error("directlight: cannot init light");
+            return false;
+        }
+
+        AddTags(effect_desc, _lightEffect.GetNode());
+
+        return true;
+    }
+
+    private void ReadConfiguration(const JSONValue& effect_desc)
+    {
+        _lightConfig.Set("type", JSONValue("direct"));
+
+        if (effect_desc.Contains("color") && effect_desc.Get("color").isArray)
+            _lightConfig.Set("color", effect_desc.Get("color"));
+
+        if (effect_desc.Contains("tag") && effect_desc.Get("tag").isString)
+            _lightConfig.Set("tag", effect_desc.Get("tag"));
+
+        if (effect_desc.Contains("direction") && effect_desc.Get("direction").isArray)
+            _lightConfig.Set("direction", effect_desc.Get("direction"));
+
+        if (effect_desc.Contains("rotation") && effect_desc.Get("rotation").isArray)
+            _lightConfig.Set("rotation", effect_desc.Get("rotation"));
+
+        if (effect_desc.Contains("brightness") && effect_desc.Get("brightness").isNumber)
+            _lightConfig.Set("brightness", effect_desc.Get("brightness"));
+
+        if (effect_desc.Contains("specular_intensity") && effect_desc.Get("specular_intensity").isNumber)
+            _lightConfig.Set("specular_intensity", effect_desc.Get("specular_intensity"));
+    }
+
+    void _SetVisible(bool visible) override
+    {
+        _lightEffect.SetVisible(visible);
+    }
+
+    String GetName() override
+    {
+        return "directlight";
+    }
+}
+
+}

--- a/ScriptEngine/Effects/light.as
+++ b/ScriptEngine/Effects/light.as
@@ -1,5 +1,6 @@
 #include "ScriptEngine/Effects/Base/BaseEffect.as"
 
+
 namespace MaskEngine
 {
 
@@ -56,6 +57,7 @@ class light : BaseEffectImpl
                 Node@ faceNode = scene.GetChild(_faceNodeName);
                 if (faceNode !is null)
                 {
+                    log.Error("light: Failed to find face node");
                     return false;
                 }
                 _anchorNode = faceNode.CreateChild("Light_anchor");
@@ -104,12 +106,10 @@ class light : BaseEffectImpl
         light.lightType = light_type;
         light.range = 500.0f;
 
+        Vector3 color;
+        if (ReadVector3(effect_desc.Get("color"), color))
         {
-            Vector3 color;
-            if (ReadVector3(effect_desc.Get("color"), color))
-            {
-                light.color = Color(color.x, color.y, color.z);
-            }
+            light.color = Color(color.x, color.y, color.z);
         }
 
         if (effect_desc.Get("specular_intensity").isNumber)
@@ -134,7 +134,6 @@ class light : BaseEffectImpl
 
         Array<String> reservedField;
         _inited = LoadAddons(effect_desc, reservedField);
-
 
         return _inited;
     }

--- a/ScriptEngine/Effects/pointlight.as
+++ b/ScriptEngine/Effects/pointlight.as
@@ -1,0 +1,76 @@
+#include "ScriptEngine/Effects/Base/BaseEffect.as"
+
+namespace MaskEngine
+{
+
+class pointlight : BaseEffectImpl
+{
+    private BaseEffect@ _lightEffect;
+    private JSONValue _lightConfig;
+
+    bool Init(const JSONValue& effect_desc, BaseEffect@ parent) override
+    {
+        if (!BaseEffectImpl::Init(effect_desc, parent))
+        {
+            return false;
+        }
+
+        _lightConfig = JSONValue();
+        ReadConfiguration(effect_desc);
+
+        @_lightEffect = AddChildEffect("light");
+        if (_lightEffect is null)
+        {
+            log.Error("pointlight: light effect is null");
+            return false;
+        }
+
+        if (!_lightEffect.Init(_lightConfig, parent))
+        {
+            log.Error("pointlight: cannot init light");
+            return false;
+        }
+
+        AddTags(effect_desc, _lightEffect.GetNode());
+
+        return true;
+    }
+
+    private void ReadConfiguration(const JSONValue& effect_desc)
+    {
+        _lightConfig.Set("type", JSONValue("point"));
+
+        if (effect_desc.Contains("color") && effect_desc.Get("color").isArray)
+            _lightConfig.Set("color", effect_desc.Get("color"));
+
+        if (effect_desc.Contains("tag") && effect_desc.Get("tag").isString)
+            _lightConfig.Set("tag", effect_desc.Get("tag"));
+
+        if (effect_desc.Contains("anchor") && effect_desc.Get("anchor").isString)
+            _lightConfig.Set("anchor", effect_desc.Get("anchor"));
+
+        if (effect_desc.Contains("position") && effect_desc.Get("position").isArray)
+            _lightConfig.Set("position", effect_desc.Get("position"));
+
+        if (effect_desc.Contains("range") && effect_desc.Get("range").isNumber)
+            _lightConfig.Set("range", effect_desc.Get("range"));
+
+        if (effect_desc.Contains("brightness") && effect_desc.Get("brightness").isNumber)
+            _lightConfig.Set("brightness", effect_desc.Get("brightness"));
+
+        if (effect_desc.Contains("specular_intensity") && effect_desc.Get("specular_intensity").isNumber)
+            _lightConfig.Set("specular_intensity", effect_desc.Get("specular_intensity"));
+    }
+
+    void _SetVisible(bool visible) override
+    {
+        _lightEffect.SetVisible(visible);
+    }
+
+    String GetName() override
+    {
+        return "pointlight";
+    }
+}
+
+}

--- a/ScriptEngine/Src/MaskScene.as
+++ b/ScriptEngine/Src/MaskScene.as
@@ -81,8 +81,11 @@ class MaskScene
 
         for (uint i = 0; i < mask.effects.length; i++)
         {
-            if (mask.effects[i].GetName() == "light")
-            {
+            if (mask.effects[i].GetName() == "light" ||
+                mask.effects[i].GetName() == "ambientlight" ||
+                mask.effects[i].GetName() == "directlight" ||
+                mask.effects[i].GetName() == "pointlight"
+            ) {
                 has_custom_lights = true;
                 break;
             }


### PR DESCRIPTION
Added three new effects for light sources: `ambientlight`, `directlight`, `pointlight`.  These new effects create under the hood the existing `light` effect with corresponding type and parameters.  Still possible to create old `ligh` effect for backward compatibility.

*Turns out, the light source of type point cannon be created now due to the fact that in line 57 of `light.as`
```AngelScript
Node@ faceNode = scene.GetChild(_faceNodeName);
```
`faceNode` is null.