### PR TITLE
Added Animated Rotation Plugin & `model3d` supports `allow_rotation`

### DIFF
--- a/ScriptEngine/Effects/model3d.as
+++ b/ScriptEngine/Effects/model3d.as
@@ -322,6 +322,7 @@ class model3d : BaseEffectImpl
     VariantMap handGestureData;
     Vector3 _node_initial_scale;
     Vector3 _anchor_node_initial_scale;
+    bool _allow_rotation = true;
 
     // Child wiggle effect
     BaseEffect@ _wiggly;
@@ -482,6 +483,9 @@ class model3d : BaseEffectImpl
         Array<String> reservedField;
         reservedField.Push("animation");
         reservedField.Push("material");
+
+        if (effect_desc.Get("allow_rotation").isBool)
+            _allow_rotation = effect_desc.Get("allow_rotation").GetBool();
         
         // Wiggle injection point
         if (effect_desc.Contains("wiggle"))
@@ -1052,6 +1056,11 @@ class model3d : BaseEffectImpl
                 {
                     _SetVisible(false);
                 }
+            }
+
+            if (!_allow_rotation)
+            {
+                _anchorNode.rotation = _anchorNode.parent.rotation.Inverse();
             }
         }
     }

--- a/ScriptEngine/Plugins/animatedrotation.as
+++ b/ScriptEngine/Plugins/animatedrotation.as
@@ -1,0 +1,77 @@
+#include "ScriptEngine/Plugins/BasePlugin.as"
+
+
+class animatedrotation : BasePlugin
+{
+    String pluginName = "animatedrotation";
+
+    String __effect_tag = "";
+    float __speed = 1.0;
+
+    Node@ m_faceNode;
+    Node@ m_cylinderNode;
+
+    bool Init(const JSONValue& plugin_config, MaskEngine::Mask@ mask) override
+    {
+        LoadSettings(plugin_config);
+
+        if (__effect_tag.empty)
+        {
+            log.Error(pluginName + ": 'tag' must have a string value");
+            return false;
+        }
+
+        Array<Node@> nodes = scene.GetChildrenWithTag(__effect_tag, true);
+        if (nodes.empty)
+        {
+            log.Error(pluginName + ": unable to find at least one node with tag '" + __effect_tag + "'");
+            return false;
+        }
+        m_cylinderNode = nodes[0];
+
+        float direction = -Sign(__speed);
+
+        ValueAnimation@ rotation = ValueAnimation();
+        rotation.SetKeyFrame(0.0, Variant(QuatY(0.0)));
+        rotation.SetKeyFrame(0.5, Variant(QuatY(180.0 * direction)));
+        rotation.SetKeyFrame(1.0, Variant(QuatY(360.0 * direction)));
+        m_cylinderNode.SetAttributeAnimation("Rotation", rotation, WM_LOOP, 0.05 * Abs(__speed));
+
+        return true;
+    }
+
+    void LoadSettings(const JSONValue& plugin_config) override
+    {
+        if (plugin_config.Get("name").GetString().ToLower() == pluginName)
+        {
+            if (plugin_config.Contains("tag"))
+                __effect_tag = plugin_config.Get("tag").GetString();
+
+            if (plugin_config.Contains("speed"))
+                __speed = plugin_config.Get("speed").GetFloat();
+        }
+    }
+
+    void HandleUpdate(StringHash eventType, VariantMap& eventData)
+    {
+        m_faceNode = scene.GetChild("Face");
+        if (m_faceNode is null) {
+            return;
+        }
+        m_faceNode.rotation = QuatZero();
+    }
+
+    Quaternion QuatZero()
+    {
+        Quaternion q = Quaternion();
+        q.FromEulerAngles(0.0, 0.0, 0.0);
+        return q;
+    }
+
+    Quaternion QuatY(float angle)
+    {
+        Quaternion q = Quaternion();
+        q.FromEulerAngles(0.0, angle, 0.0);
+        return q;
+    }
+}

--- a/ScriptEngine/Utils.as
+++ b/ScriptEngine/Utils.as
@@ -268,4 +268,11 @@ bool FileExists(String& filename)
     return file !is null;
 }
 
+Quaternion QuaternionZero()
+{
+    Quaternion q = Quaternion();
+    q.FromEulerAngles(0.0, 0.0, 0.0);
+    return q;
+}
+
 }


### PR DESCRIPTION
Добавлен плагин `AnimatedRotationPlugin`, который позволяет анимировать эффект `model3d` так, чтобы он вращался с привязкой к лицу.

Добавлена возможность у `model3d` задавать параметр `"allow_rotation": true / false`.

В Utilities добавлена функция, возвращающая кватернион нулевого вращения.