### PR TITLE
Fix mouth triggers for model3d visibility and texture animation

### DIFF
--- a/ScriptEngine/Effects/Base/BaseEvent.as
+++ b/ScriptEngine/Effects/Base/BaseEvent.as
@@ -18,7 +18,7 @@ class BaseEvent : BaseEffectImpl
     // Initialise with JSONValue with some BaseAction
     bool Init(const JSONValue& effect_desc, BaseEffect@ parent) override
     {
-        if (!BaseEffectImpl::Init(effect_desc, parent))
+        if (effect_desc.valueType == JSON_NULL || !BaseEffectImpl::Init(effect_desc, parent))
             return false;
 
         if (effect_desc.isString)
@@ -30,7 +30,7 @@ class BaseEvent : BaseEffectImpl
             // But action is also among the `_childern` of event...
             if (!action.Init(parent))
             {
-                log.Error("BaseEvent: Cannot init " + actionName  + " for patch");
+                log.Error("BaseEvent: Cannot init " + actionName  + " for " + parent.GetName());
                 return false;
             }
 
@@ -44,7 +44,7 @@ class BaseEvent : BaseEffectImpl
                 BaseEffect@ action = AddChildEffect(actionName);
                 if (!action.Init(effect_desc, parent))
                 {
-                    log.Error("BaseEvent: Cannot init " + actionName + " for patch");
+                    log.Error("BaseEvent: Cannot init " + actionName  + " for " + parent.GetName());
                     return false;
                 }
             }

--- a/ScriptEngine/Effects/model3d.as
+++ b/ScriptEngine/Effects/model3d.as
@@ -75,10 +75,22 @@ class model_texture_animation
         if (trigger_start == "face_found" || trigger_stop == "face_lost")
             SubscribeToEvent("UpdateFaceDetected", "HandleFaceDetected");
 
+        if (trigger_start == "mouth_open")
+            SubscribeToEvent("MouthTrigger", "HandleMouthTrigger");
+
         if (HAND_GESTURE_NAMES.Find(trigger_start) != -1 || HAND_GESTURE_NAMES.Find(trigger_stop) != -1)
             SubscribeToEvent("UpdateHandGesture", "HandleUpdateHandGesture");
 
         SubscribeToEvent("Update", "HandleUpdate");
+    }
+
+    private void HandleMouthTrigger(StringHash eventType, VariantMap& eventData)
+    {
+        if (eventData["NFace"].GetUInt() != 0 || !eventData["Opened"].GetBool())
+            return;
+
+        if (!running)
+            start();
     }
 
     private bool parse_description(JSONValue& texture_desc)
@@ -293,7 +305,7 @@ class model_texture_animation
             if (animation_type == "once" && elapsedTime >= duration)
             // if (animation_type == "once" && frame >= texturePaths.length)
             {
-                stop(trigger_start == "tap");
+                stop(trigger_start == "tap" || trigger_start == "mouth_open");
                 return;
             }
 
@@ -413,11 +425,15 @@ class model3d : BaseEffectImpl
             }
 
         // Visibility Triggers
-        if (effect_desc.Get("visible").GetString() == "mouth_open")
+        String visibleTrigger = effect_desc.Get("visible").GetString();
+        if (visibleTrigger == "mouth_open" || visibleTrigger == "mouth_close")
         {
             Array<String> events     = { "mouth_open"  , "mouth_close" };
             Array<String> actions    = { "show_action" , "hide_action" };
             Array<String> delayParam = { "show_delay"  , "hide_delay"  };
+            
+            if (visibleTrigger == "mouth_close")
+                events.Reverse();
 
             for (uint i = 0; i < events.length; i++)
             {
@@ -426,28 +442,28 @@ class model3d : BaseEffectImpl
 
                 if (mouthOpen is null)
                 {
-                    log.Error("Cannot create mouthOpen for patch");
+                    log.Error("Cannot init mouth_open for model3d");
                     return false;
                 }
 
                 String json;
 
                 if (effect_desc.Contains(delayParam[i]))
-                    json = "{ \"name\" : \"" + actions[i] + "\"," +
+                    json = "{ \"name\": \"" + actions[i] + "\"," +
                         "\"delay\":" + effect_desc.Get(delayParam[i]).GetFloat() + "}";
                 else
-                    json = actions[i];
+                    json = "{ \"name\": \"" + actions[i] + "\" }";
 
                 JSONFile@ jsonFile = JSONFile();
                 jsonFile.FromString(json);
 
                 if (!mouthOpen.Init(jsonFile.GetRoot(), this))
                 {
-                    log.Error("Cannot init mouthOpen for patch");
+                    log.Error("Cannot init mouth_open for model3d");
                     return false;
                 }
             }
-            _visible = false;
+            _visible = visibleTrigger == "mouth_close";
         }
 
         // Init position / rotation / scale
@@ -1082,6 +1098,13 @@ class model3d : BaseEffectImpl
     Array<Material@> GetMaterials() 
     {
         return materials;
+    }
+
+    Material@ GetMaterial() override
+    {
+        if (!materials.empty)
+            return materials[0];
+        return null;
     }
 
     BaseAnimation@ GetAnimation() override


### PR DESCRIPTION
Добавлена возможность задавать `"trigger_start": "mouth_open"` для анимации текстур `model3d`.

Исправлена инициализация триггеров при задании `"visible": "mouth_open" / "mouth_close"` для `model3d`.